### PR TITLE
RoboService uses the deprecated "onStart" instead of "onStartCommand"

### DIFF
--- a/roboguice/src/main/java/roboguice/service/RoboService.java
+++ b/roboguice/src/main/java/roboguice/service/RoboService.java
@@ -66,9 +66,10 @@ public abstract class RoboService extends Service implements RoboContext {
     }
 
     @Override
-    public void onStart(Intent intent, int startId) {
-        super.onStart(intent, startId);
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        int startCont = super.onStartCommand(intent,flags, startId);
         eventManager.fire(new OnStartEvent());
+        return startCont;
     }
 
     @Override


### PR DESCRIPTION
Pull request with the fix is attached. 
