### PR TITLE
Fixed @InjectFragment(String tag)

### DIFF
--- a/roboguice/src/main/java/roboguice/inject/ViewListener.java
+++ b/roboguice/src/main/java/roboguice/inject/ViewListener.java
@@ -50,7 +50,7 @@ public class ViewListener implements TypeListener {
             fragmentManagerClass = Class.forName("android.support.v4.app.FragmentManager");
             fragmentGetViewMethod = fragmentClass.getDeclaredMethod("getView");
             fragmentFindFragmentByIdMethod = fragmentManagerClass.getMethod("findFragmentById", int.class);
-            fragmentFindFragmentByTagMethod = fragmentManagerClass.getMethod("findFragmentByTag",Object.class);
+            fragmentFindFragmentByTagMethod = fragmentManagerClass.getMethod("findFragmentByTag", String.class);
         } catch( Throwable ignored ) {}
     }
 


### PR DESCRIPTION
The FragmentManager.findFragmentByTag method takes a String, not an Object. This caused fragmentFindFragmentByTagMethod in ViewListener to be null and thus a NullReferenceException in
ViewListener.reallyInjectMemberFragments(Object)
