### PR TITLE
Adding Apache 2.0 License (like on Google Code)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2009-2013 roboguice committers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
same as listed at https://code.google.com/p/roboguice/

I just put the copyright holder as 'roboguice committers.' Happy to change it if requested, but I think we should have a license in this repository since it's the new home of the project

Thanks! 
