### PR TITLE
fix for ConcurrentModificationException in EventManager: now copy of observers set is created

### DIFF
--- a/astroboy/pom.xml
+++ b/astroboy/pom.xml
@@ -73,7 +73,7 @@
             <plugin>
                 <groupId>com.jayway.maven.plugins.android.generation2</groupId>
                 <artifactId>android-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.7.0</version>
                 <configuration>
                     <androidManifestFile>${project.basedir}/AndroidManifest.xml</androidManifestFile>
                     <assetsDirectory>${project.basedir}/assets</assetsDirectory>

--- a/roboguice/src/main/java/roboguice/event/EventManager.java
+++ b/roboguice/src/main/java/roboguice/event/EventManager.java
@@ -123,16 +123,22 @@ public class EventManager {
         final Set<EventListener<?>> observers = registrations.get(event.getClass());
         if (observers == null) return;
 
+        for (EventListener observer : copyObservers(observers))
+            observer.onEvent(event);
+
+    }
+
+    private Set<EventListener<?>> copyObservers(Set<EventListener<?>> observers) {
+        final Set<EventListener<?>> copy;
         // As documented in http://docs.oracle.com/javase/1.4.2/docs/api/java/util/Collections.html#synchronizedSet(java.util.Set)
         //noinspection SynchronizationOnLocalVariableOrMethodParameter
         synchronized (observers) {
-            for (EventListener observer : observers)
-                observer.onEvent(event);
+            copy = new LinkedHashSet<EventListener<?>>(observers);
         }
-
+        return copy;
     }
-    
-    
+
+
     public void destroy() {
         for( Entry<Class<?>, Set<EventListener<?>>> e : registrations.entrySet() )
             e.getValue().clear();

--- a/roboguice/src/test/java/roboguice/event/EventManagerTest.java
+++ b/roboguice/src/test/java/roboguice/event/EventManagerTest.java
@@ -2,10 +2,13 @@ package roboguice.event;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import roboguice.event.eventListener.ObserverMethodListener;
 
 import java.lang.reflect.Method;
 import java.util.List;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Test class verifying eventManager functionality
@@ -54,5 +57,19 @@ public class EventManagerTest {
 
         tester.verifyCallCount(eventOneMethods, EventOne.class, 0);
         tester.verifyCallCount(eventTwoMethods, EventTwo.class, 0);
+    }
+
+    @Test
+    public void testShouldNotFailIfObserverIsRemovedInsideFire() throws Exception {
+        eventManager.registerObserver(EventOne.class, new EventListener<EventOne>() {
+            @Override
+            public void onEvent(EventOne event) {
+                // unregister self from manager
+                eventManager.unregisterObserver(EventOne.class, this);
+            }
+        });
+        eventManager.registerObserver(EventOne.class, mock(EventListener.class));
+
+        eventManager.fire(event);
     }
 }


### PR DESCRIPTION
Two problems fixed:
1. Concurrent modification of observers set in case if this set is changed due to change in onEvent() method
2. Synchronization block reduced - now only copy of set is synchronized, onEvent() calls are not synchronized
