### PR TITLE
Is it really deprecated? if not, please remove the annotation.

### DIFF
--- a/roboguice/src/main/java/roboguice/util/SafeAsyncTask.java
+++ b/roboguice/src/main/java/roboguice/util/SafeAsyncTask.java
@@ -20,8 +20,6 @@ import java.util.concurrent.*;
  * 
  * @param <ResultT>
  */
-@SuppressWarnings("deprecation")
-@Deprecated
 public abstract class SafeAsyncTask<ResultT> implements Callable<ResultT> {
     public static final int DEFAULT_POOL_SIZE = 25;
     protected static final Executor DEFAULT_EXECUTOR = Executors.newFixedThreadPool(DEFAULT_POOL_SIZE);


### PR DESCRIPTION
I think SafeAsyncTask is very useful.
Time passed, I noteced there's big change: AndroidCallable.

But, it may not the reason why SafeAsyncTask has @Deprecated annotation.
I can't find the reason in your commit log.

If it's not tiresome work, and it's not really deprecated,
please remove these tow annotations.

Thank you.
