### PR TITLE
Try some optimization to speed up start up time. Clean up.

### DIFF
--- a/roboguice/src/main/java/roboguice/event/ObservesTypeListener.java
+++ b/roboguice/src/main/java/roboguice/event/ObservesTypeListener.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Method;
 
 import roboguice.event.eventListener.ObserverMethodListener;
 import roboguice.event.eventListener.factory.EventListenerThreadingDecorator;
+import roboguice.util.GuiceInjectionMonitor;
 
 import com.google.inject.Provider;
 import com.google.inject.TypeLiteral;
@@ -29,15 +30,14 @@ public class ObservesTypeListener implements TypeListener {
     }
 
     public <I> void hear(TypeLiteral<I> iTypeLiteral, TypeEncounter<I> iTypeEncounter) {
-        for( Class<?> c = iTypeLiteral.getRawType(); c!=Object.class ; c = c.getSuperclass() ) {
+        GuiceInjectionMonitor gim = new GuiceInjectionMonitor();
+        for (Class<?> c = iTypeLiteral.getRawType(); gim.isWorthInjecting(c); c = c.getSuperclass()) {
             for (Method method : c.getDeclaredMethods())
                 findContextObserver(method, iTypeEncounter);
 
             for( Class<?> interfaceClass : c.getInterfaces())
                 for (Method method : interfaceClass.getDeclaredMethods())
                     findContextObserver(method, iTypeEncounter);
-
-            
         }
     }
 

--- a/roboguice/src/main/java/roboguice/inject/ExtrasListener.java
+++ b/roboguice/src/main/java/roboguice/inject/ExtrasListener.java
@@ -21,6 +21,7 @@ import java.lang.reflect.ParameterizedType;
 import java.util.Map;
 
 import roboguice.RoboGuice;
+import roboguice.util.GuiceInjectionMonitor;
 
 import com.google.inject.Binding;
 import com.google.inject.Injector;
@@ -49,8 +50,8 @@ public class ExtrasListener implements TypeListener {
     }
 
     public <I> void hear(TypeLiteral<I> typeLiteral, TypeEncounter<I> typeEncounter) {
-
-        for( Class<?> c = typeLiteral.getRawType(); c!=Object.class; c=c.getSuperclass() )
+        GuiceInjectionMonitor gim = new GuiceInjectionMonitor();
+        for (Class<?> c = typeLiteral.getRawType(); gim.isWorthInjecting(c); c = c.getSuperclass()) {
             for (Field field : c.getDeclaredFields())
                 if (field.isAnnotationPresent(InjectExtra.class) )
                     if( Modifier.isStatic(field.getModifiers()) )
@@ -58,7 +59,7 @@ public class ExtrasListener implements TypeListener {
                     else
                         typeEncounter.register(new ExtrasMembersInjector<I>(field, contextProvider, field.getAnnotation(InjectExtra.class)));
 
-
+        }
     }
 
 

--- a/roboguice/src/main/java/roboguice/inject/ResourceListener.java
+++ b/roboguice/src/main/java/roboguice/inject/ResourceListener.java
@@ -18,6 +18,8 @@ package roboguice.inject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
+import roboguice.util.GuiceInjectionMonitor;
+
 import com.google.inject.MembersInjector;
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.TypeEncounter;
@@ -31,9 +33,9 @@ import android.graphics.drawable.Drawable;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 
-
 /**
  * Resource listener.
+ * 
  * @author Mike Burton
  */
 public class ResourceListener implements TypeListener {
@@ -44,21 +46,17 @@ public class ResourceListener implements TypeListener {
     }
 
     public <I> void hear(TypeLiteral<I> typeLiteral, TypeEncounter<I> typeEncounter) {
-        
-        for( Class<?> c = typeLiteral.getRawType(); c!=Object.class; c = c.getSuperclass() )
+
+        GuiceInjectionMonitor gim = new GuiceInjectionMonitor();
+        for (Class<?> c = typeLiteral.getRawType(); gim.isWorthInjecting(c); c = c.getSuperclass()) {
+
             for (Field field : c.getDeclaredFields())
-                if ( field.isAnnotationPresent(InjectResource.class) && !Modifier.isStatic(field.getModifiers()) )
+                if (field.isAnnotationPresent(InjectResource.class) && !Modifier.isStatic(field.getModifiers()))
                     typeEncounter.register(new ResourceMembersInjector<I>(field, application, field.getAnnotation(InjectResource.class)));
+        }
 
     }
 
-
-
-
-
-
-
-    
     protected static class ResourceMembersInjector<T> implements MembersInjector<T> {
 
         protected Field field;
@@ -78,14 +76,14 @@ public class ResourceListener implements TypeListener {
             try {
 
                 final Resources resources = application.getResources();
-                final int id = getId(resources,annotation);
+                final int id = getId(resources, annotation);
                 final Class<?> t = field.getType();
 
                 if (String.class.isAssignableFrom(t)) {
                     value = resources.getString(id);
                 } else if (boolean.class.isAssignableFrom(t) || Boolean.class.isAssignableFrom(t)) {
                     value = resources.getBoolean(id);
-                } else if (ColorStateList.class.isAssignableFrom(t)  ) {
+                } else if (ColorStateList.class.isAssignableFrom(t)) {
                     value = resources.getColorStateList(id);
                 } else if (int.class.isAssignableFrom(t) || Integer.class.isAssignableFrom(t)) {
                     value = resources.getInteger(id);
@@ -97,13 +95,13 @@ public class ResourceListener implements TypeListener {
                     value = resources.getIntArray(id);
                 } else if (Animation.class.isAssignableFrom(t)) {
                     value = AnimationUtils.loadAnimation(application, id);
-                } else if (Movie.class.isAssignableFrom(t)  ) {
+                } else if (Movie.class.isAssignableFrom(t)) {
                     value = resources.getMovie(id);
                 }
 
-                if (value == null && Nullable.notNullable(field) ) {
-                    throw new NullPointerException(String.format("Can't inject null value into %s.%s when field is not @Nullable", field.getDeclaringClass(), field
-                            .getName()));
+                if (value == null && Nullable.notNullable(field)) {
+                    throw new NullPointerException(String.format("Can't inject null value into %s.%s when field is not @Nullable", field.getDeclaringClass(),
+                            field.getName()));
                 }
 
                 field.setAccessible(true);
@@ -120,8 +118,7 @@ public class ResourceListener implements TypeListener {
 
         protected int getId(Resources resources, InjectResource annotation) {
             int id = annotation.value();
-            return id>=0 ? id : resources.getIdentifier(annotation.name(),null,null);
+            return id >= 0 ? id : resources.getIdentifier(annotation.name(), null, null);
         }
     }
 }
-

--- a/roboguice/src/main/java/roboguice/inject/ViewListener.java
+++ b/roboguice/src/main/java/roboguice/inject/ViewListener.java
@@ -15,20 +15,6 @@
  */
 package roboguice.inject;
 
-import android.app.Activity;
-import android.content.Context;
-import android.view.View;
-
-import roboguice.fragment.FragmentUtil;
-import roboguice.fragment.FragmentUtil.f;
-
-import com.google.inject.MembersInjector;
-import com.google.inject.Provider;
-import com.google.inject.TypeLiteral;
-import com.google.inject.spi.TypeEncounter;
-import com.google.inject.spi.TypeListener;
-
-import javax.inject.Singleton;
 import java.lang.annotation.Annotation;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
@@ -36,14 +22,30 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.WeakHashMap;
 
+import javax.inject.Singleton;
+
+import roboguice.fragment.FragmentUtil;
+import roboguice.fragment.FragmentUtil.f;
+import roboguice.util.GuiceInjectionMonitor;
+
+import com.google.inject.MembersInjector;
+import com.google.inject.Provider;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.View;
+
 @Singleton
 @SuppressWarnings({"unchecked","PMD"})
 public class ViewListener implements TypeListener {
        
     @Override
     public <I> void hear(TypeLiteral<I> typeLiteral, TypeEncounter<I> typeEncounter) {
-
-        for (Class<?> c = typeLiteral.getRawType(); c != Object.class; c = c.getSuperclass())
+        GuiceInjectionMonitor gim = new GuiceInjectionMonitor();
+        for (Class<?> c = typeLiteral.getRawType(); gim.isWorthInjecting(c); c = c.getSuperclass()) {
             for (Field field : c.getDeclaredFields()) {
                 if (field.isAnnotationPresent(InjectView.class))
                     if (Modifier.isStatic(field.getModifiers()))
@@ -53,7 +55,7 @@ public class ViewListener implements TypeListener {
                     else if (Context.class.isAssignableFrom(field.getDeclaringClass()) && !Activity.class.isAssignableFrom(field.getDeclaringClass()))
                         throw new UnsupportedOperationException("You may only use @InjectView in Activity contexts");
                     else {
-                        final f<?,?> utils = FragmentUtil.hasSupport 
+                        final f<?,?> utils = FragmentUtil.hasSupport
                                 && (FragmentUtil.supportActivity.isAssignableFrom(field.getDeclaringClass())
                                         || FragmentUtil.supportFrag.fragmentType().isAssignableFrom(field.getDeclaringClass()))
                                         ? FragmentUtil.supportFrag : FragmentUtil.nativeFrag;
@@ -92,6 +94,7 @@ public class ViewListener implements TypeListener {
                         }
                     }
             }
+        }
     }
 
 

--- a/roboguice/src/main/java/roboguice/util/GuiceInjectionMonitor.java
+++ b/roboguice/src/main/java/roboguice/util/GuiceInjectionMonitor.java
@@ -1,0 +1,43 @@
+package roboguice.util;
+
+import roboguice.RoboGuice;
+
+/**
+ * Monitors the state of type hierarchy when injecting a given type via Guice.
+ * This class allows to prune the type hierarchy when looking for injection points.
+ * It is based on the following observations : 
+ * <pre> <i>
+ * If a class A extends B and B extends C,
+ * then if B is inside android package, then B can't 
+ * contains injections points.
+ *
+ * If B is inside RoboGuice package, or "subpackages", then it may
+ * receive injections. A is probably a custom app class or a roboguice test
+ * and it may contain injections as well. But if C doesn't belong to roboguice,
+ * then we went too high inside the type hierarchy and it's not worth having a look
+ * at class C and ascendants.
+ * </i></pre>
+ * @author SNI
+ */
+public class GuiceInjectionMonitor {
+
+    private static final String ANDROID_PACKAGE = "android";
+    protected static final String ROBOGUICE_PACKAGE = RoboGuice.class.getPackage().getName();
+
+    private boolean isInRoboGuicePackage = false;
+
+    public boolean isWorthInjecting(Class<?> c) {
+        if( c == null || c == Object.class) {
+            return false;
+        }
+        String className = c.getName();
+        if( className.startsWith(ANDROID_PACKAGE) ) {
+            return false;
+        } else if( className.startsWith(ROBOGUICE_PACKAGE)) {
+            isInRoboGuicePackage = true;
+        } else if( isInRoboGuicePackage ) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/roboguice/src/test/java/roboguice/util/GuiceInjectionMonitorTest.java
+++ b/roboguice/src/test/java/roboguice/util/GuiceInjectionMonitorTest.java
@@ -1,0 +1,84 @@
+package roboguice.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import roboguice.RoboGuice;
+
+import android.app.Activity;
+
+public class GuiceInjectionMonitorTest {
+
+    @Test
+    public void testRejectAndroidClass() {
+        //given
+        GuiceInjectionMonitor gim = new GuiceInjectionMonitor();
+        Class<?> c = Activity.class;
+        
+        //when
+        boolean worthInjecting = gim.isWorthInjecting(c);
+        
+        //then
+        assertFalse( worthInjecting );
+    }
+
+    @Test
+    public void testRejectNull() {
+        //given
+        GuiceInjectionMonitor gim = new GuiceInjectionMonitor();
+        Class<?> c = null;
+        
+        //when
+        boolean worthInjecting = gim.isWorthInjecting(c);
+        
+        //then
+        assertFalse( worthInjecting );
+    }
+
+    @Test
+    public void testRejectObject() {
+        //given
+        GuiceInjectionMonitor gim = new GuiceInjectionMonitor();
+        Class<?> c = Object.class;
+        
+        //when
+        boolean worthInjecting = gim.isWorthInjecting(c);
+        
+        //then
+        assertFalse( worthInjecting );
+    }
+
+    @Test
+    public void testAcceptInRoboGuiceClass() {
+        //given
+        GuiceInjectionMonitor gim = new GuiceInjectionMonitor();
+        Class<?> c = RoboGuice.class;
+        
+        //when
+        boolean worthInjecting = gim.isWorthInjecting(c);
+        
+        //then
+        assertTrue( worthInjecting );
+    }
+
+    @Test
+    public void testRejectClassHigherThanRoboGuice() {
+        //given
+        GuiceInjectionMonitor gim = new GuiceInjectionMonitor();
+        Class<?> c1 = String.class;
+        Class<?> c2 = RoboGuice.class;
+        
+        //when
+        boolean worthInjecting = gim.isWorthInjecting(c1);
+        boolean worthInjecting2 = gim.isWorthInjecting(c2);
+        boolean worthInjecting3 = gim.isWorthInjecting(c1);
+        
+        //then
+        assertTrue( worthInjecting );
+        assertTrue( worthInjecting2 );
+        assertFalse( worthInjecting3 );
+    }
+
+}


### PR DESCRIPTION
Mentionned in PR #169, this is an attempt to limit the space search for RoboGuice when injecting stuff. It will discard a few classes that can't receive injections. 

The main Idea is expressed by the javadoc of the new GuiceInjectionMonitor's javadoc : 

```
/*
 * Monitors the state of type hierarchy when injecting a given type via Guice.
 * This class allows to prune the type hierarchy when looking for injection points.
 * It is based on the following observations : 
 * <pre> <i>
 * If a class A extends B and B extends C,
 * then if B is inside android package, then B can't 
 * contains injections points.
 *
 * If B is inside RoboGuice package, or "subpackages", then it may
 * receive injections. A is probably a custom app class or a roboguice test
 * and it may contain injections as well. But if C doesn't belong to roboguice,
 * then we went too high inside the type hierarchy and it's not worth having a look
 * at class C and ascendants.
 * </i></pre>
 * @author SNI
 */
```

I am afraid of the impact on obfuscation, and would love to hear from any given measure of the optimization, apart from rationale and experience.

I this track is valid, there might be even harder optimizations to find like only making Views or Activities or Fragment aware of view injections, stuff like that.

BTW, I would be at ease to add testing if the PR is accepted.
