### PR TITLE
Injecting resources by name in a library doesn't work

### DIFF
--- a/roboguice/src/main/java/roboguice/inject/ResourceListener.java
+++ b/roboguice/src/main/java/roboguice/inject/ResourceListener.java
@@ -120,7 +120,7 @@ public class ResourceListener implements TypeListener {
 
         protected int getId(Resources resources, InjectResource annotation) {
             int id = annotation.value();
-            return id>=0 ? id : resources.getIdentifier(annotation.name(),null,null);
+            return id>=0 ? id : resources.getIdentifier(annotation.name(),null,application.getPackageName());
         }
     }
 }


### PR DESCRIPTION
Scenario:
- A library project with package com.library.package
- An app project referencing the library with package com.app.package.

If you inject a resource like this:

```
@InjectResource(name="com.library.package:string/mytext")
private String myText;
```

it will not work, since Resources.getIdentifier() returns 0 if the specified package is the library package.

However, the following binding works ok:

```
@InjectResource(name="com.app.package:string/mytext")
private String myText;
```

but referencing app package from library code creates unnecessary coupling.

This could be avoided by changing ResourceListener. getId() method could be changed from:

```
    protected int getId(Resources resources, InjectResource annotation) {
        int id = annotation.value();
        return id>=0 ? id : resources.getIdentifier(annotation.name(),null,null);
    }
```

to

```
    protected int getId(Resources resources, InjectResource annotation) {
        int id = annotation.value();
        return id>=0 ? id : resources.getIdentifier(annotation.name(),null,application.getPackageName());
    }
```

This way, annotating the resource as:

```
@InjectResource(name="string/mytext")
private String myText;
```

will work ok, since app package is set as default.
