### PR TITLE
Fragment scope. Works and passes all tests.

### DIFF
--- a/roboguice/src/main/java/roboguice/config/DefaultRoboModule.java
+++ b/roboguice/src/main/java/roboguice/config/DefaultRoboModule.java
@@ -1,6 +1,46 @@
 package roboguice.config;
 
-import android.app.*;
+import roboguice.activity.RoboActivity;
+import roboguice.event.EventManager;
+import roboguice.event.ObservesTypeListener;
+import roboguice.event.eventListener.factory.EventListenerThreadingDecorator;
+import roboguice.fragment.FragmentUtil;
+import roboguice.inject.AccountManagerProvider;
+import roboguice.inject.AssetManagerProvider;
+import roboguice.inject.ContentResolverProvider;
+import roboguice.inject.ContextScope;
+import roboguice.inject.ContextScopedSystemServiceProvider;
+import roboguice.inject.ContextSingleton;
+import roboguice.inject.ExtrasListener;
+import roboguice.inject.FragmentScope;
+import roboguice.inject.FragmentSingleton;
+import roboguice.inject.HandlerProvider;
+import roboguice.inject.NullProvider;
+import roboguice.inject.PreferenceListener;
+import roboguice.inject.ResourceListener;
+import roboguice.inject.ResourcesProvider;
+import roboguice.inject.SharedPreferencesProvider;
+import roboguice.inject.SystemServiceProvider;
+import roboguice.inject.ViewListener;
+import roboguice.service.RoboService;
+import roboguice.util.Ln;
+import roboguice.util.LnImpl;
+import roboguice.util.LnInterface;
+import roboguice.util.Strings;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provider;
+import com.google.inject.matcher.Matchers;
+import com.google.inject.name.Names;
+
+import android.app.Activity;
+import android.app.ActivityManager;
+import android.app.AlarmManager;
+import android.app.Application;
+import android.app.KeyguardManager;
+import android.app.NotificationManager;
+import android.app.SearchManager;
+import android.app.Service;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -24,23 +64,6 @@ import android.telephony.TelephonyManager;
 import android.view.LayoutInflater;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
-
-import com.google.inject.AbstractModule;
-import com.google.inject.Provider;
-import com.google.inject.matcher.Matchers;
-import com.google.inject.name.Names;
-
-import roboguice.activity.RoboActivity;
-import roboguice.event.EventManager;
-import roboguice.event.ObservesTypeListener;
-import roboguice.event.eventListener.factory.EventListenerThreadingDecorator;
-import roboguice.fragment.FragmentUtil;
-import roboguice.inject.*;
-import roboguice.service.RoboService;
-import roboguice.util.Ln;
-import roboguice.util.LnImpl;
-import roboguice.util.LnInterface;
-import roboguice.util.Strings;
 
 /**
  * A Module that provides bindings and configuration to use Guice on Android.
@@ -78,13 +101,12 @@ public class DefaultRoboModule extends AbstractModule {
     protected ContextScope contextScope;
     protected ResourceListener resourceListener;
     protected ViewListener viewListener;
+    protected FragmentScope fragmentScope;
 
-
-    public DefaultRoboModule(final Application application, ContextScope contextScope, ViewListener viewListener, ResourceListener resourceListener) {
-
-
+    public DefaultRoboModule(final Application application, ContextScope contextScope, FragmentScope fragmentScope, ViewListener viewListener, ResourceListener resourceListener) {
         this.application = application;
         this.contextScope = contextScope;
+        this.fragmentScope = fragmentScope;
         this.viewListener = viewListener;
         this.resourceListener = resourceListener;
     }
@@ -130,7 +152,9 @@ public class DefaultRoboModule extends AbstractModule {
 
         // ContextSingleton bindings
         bindScope(ContextSingleton.class, contextScope);
+        bindScope(FragmentSingleton.class, fragmentScope);
         bind(ContextScope.class).toInstance(contextScope);
+        bind(FragmentScope.class).toInstance(fragmentScope);
         bind(AssetManager.class).toProvider(AssetManagerProvider.class);
         bind(Context.class).toProvider(NullProvider.<Context>instance()).in(ContextSingleton.class);
         bind(Activity.class).toProvider(NullProvider.<Activity>instance()).in(ContextSingleton.class);

--- a/roboguice/src/main/java/roboguice/fragment/RoboFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/RoboFragment.java
@@ -1,6 +1,12 @@
 package roboguice.fragment;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.inject.Key;
+
 import roboguice.RoboGuice;
+import roboguice.util.RoboContext;
 
 import android.annotation.TargetApi;
 import android.os.Build;
@@ -13,17 +19,30 @@ import android.view.View;
  * A RoboFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}.
  * @author Michael Burton
  */
-public abstract class RoboFragment extends Fragment {
+public abstract class RoboFragment extends Fragment implements RoboContext {
+    protected HashMap<Key<?>,Object> scopedObjects = new HashMap<Key<?>, Object>();
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        RoboGuice.getInjector(this).injectMembersWithoutViews(this);
     }
 
     @Override
     @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR2)
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        RoboGuice.getInjector(this).injectViewMembers(this);
+    }
+    
+    @Override
+    public Map<Key<?>, Object> getScopedObjectMap() {
+        return scopedObjects;
+    }
+
+    @Override
+    public void onDestroy() {
+        RoboGuice.destroyInjector(this);
+        super.onDestroy();
     }
 }

--- a/roboguice/src/main/java/roboguice/fragment/provided/RoboFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/provided/RoboFragment.java
@@ -1,6 +1,12 @@
 package roboguice.fragment.provided;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import roboguice.RoboGuice;
+import roboguice.util.RoboContext;
+
+import com.google.inject.Key;
 
 import android.annotation.TargetApi;
 import android.app.Fragment;
@@ -14,17 +20,31 @@ import android.view.View;
  * @author Charles Munger
  */
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-public abstract class RoboFragment extends Fragment {
+public abstract class RoboFragment extends Fragment implements RoboContext {
+    protected HashMap<Key<?>,Object> scopedObjects = new HashMap<Key<?>, Object>();
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        RoboGuice.getInjector(this).injectMembersWithoutViews(this);
     }
 
     @Override
     @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR2)
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        RoboGuice.getInjector(this).injectViewMembers(this);
     }
+
+    @Override
+    public Map<Key<?>, Object> getScopedObjectMap() {
+        return scopedObjects;
+    }
+
+    @Override
+    public void onDestroy() {
+        RoboGuice.destroyInjector(this);
+        super.onDestroy();
+    }
+
 }

--- a/roboguice/src/main/java/roboguice/inject/FragmentScope.java
+++ b/roboguice/src/main/java/roboguice/inject/FragmentScope.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2009 Michael Burton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package roboguice.inject;
+
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Stack;
+
+import roboguice.util.RoboContext;
+
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.Scope;
+
+import android.app.Application;
+import android.content.ContextWrapper;
+
+/**
+ * Scopes the injector based on the current fragment. As requested by issue #XXX
+ *
+ * Any usage of this class must call #enter(Context) before performing any operations with the
+ * injector, and do so within a synchronized block on the FragmentScope.class, eg:
+ * <pre>
+ * synchronized(FragmentScope.class) {
+ *     scope.enter(fragment);
+ *
+ *     // do something, eg.
+ *     // injector.injectMembers(this);
+ * }
+ * </pre>
+ * If you're using FragmentScopedRoboInjector (which is the RoboGuice default), this is done for you automatically.
+ *
+ * If you're trying to use a Provider, you must either use FragmentScopedProvider instead, or do your own synchronization
+ * and scope.enter() call.
+ *
+ * @see FragmentScopedRoboInjector
+ * @author SNI
+ */
+public class FragmentScope implements Scope {
+    //Object is used here to accomodate both native and support Fragment 
+    protected ThreadLocal<Stack<WeakReference<Object>>> contextThreadLocal = new ThreadLocal<Stack<WeakReference<Object>>>();
+    protected Map<Key<?>,Object> applicationScopedObjects = new HashMap<Key<?>, Object>();
+    protected Application application;
+
+    public FragmentScope(Application application) {
+        this.application = application;
+    }
+
+    /**
+     * You MUST perform any injector operations inside a synchronized(FragmentScope.class) block that starts with
+     * scope.enter(context) if working in a multithreaded environment
+     *
+     * @see FragmentScope
+     * @see FragmentScopedRoboInjector
+     * @see FragmentScopedProvider
+     * @param context the context to enter
+     */
+    public void enter(Object context) {
+
+        // BUG synchronizing on FragmentScope.class may be overly conservative
+        synchronized (FragmentScope.class) {
+
+            final Stack<WeakReference<Object>> stack = getContextStack();
+            final Map<Key<?>,Object> map = getScopedObjectMap(context);
+
+            // Mark this thread as for this context
+            stack.push(new WeakReference<Object>(context));
+
+            // Add the context to the scope for key Context, Activity, etc.
+            Class<?> c = context.getClass();
+            do {
+                map.put(Key.get(c), context);
+                c = c.getSuperclass();
+            } while( c!=Object.class );
+        }
+    }
+
+    public void exit(Object context) {
+        synchronized (FragmentScope.class) {
+            final Stack<WeakReference<Object>> stack = getContextStack();
+            final Object c = stack.pop().get();
+            if( c!=null && c!=context )
+                throw new IllegalArgumentException(String.format("Scope for %s must be opened before it can be closed",context));
+        }
+    }
+
+    public <T> Provider<T> scope(final Key<T> key, final Provider<T> unscoped) {
+        return new Provider<T>() {
+            public T get() {
+                synchronized (FragmentScope.class) {
+                    final Stack<WeakReference<Object>> stack = getContextStack();
+                    final Object context = stack.peek().get(); // The context should never be finalized as long as the provider is still in memory
+                    final Map<Key<?>, Object> objectsForScope = getScopedObjectMap(context);
+                    if( objectsForScope==null )
+                        return null;  // May want to consider throwing an exception here (if provider is used after onDestroy())
+
+                    @SuppressWarnings({"unchecked"}) T current = (T) objectsForScope.get(key);
+                    if (current==null && !objectsForScope.containsKey(key)) {
+                        current = unscoped.get();
+                        objectsForScope.put(key, current);
+                    }
+
+                    return current;
+                }
+            }
+        };
+
+    }
+
+
+    public Stack<WeakReference<Object>> getContextStack() {
+        Stack<WeakReference<Object>> stack = contextThreadLocal.get();
+        if( stack==null ) {
+            stack = new Stack<WeakReference<Object>>();
+            contextThreadLocal.set(stack);
+        }
+        return stack;
+    }
+
+    protected Map<Key<?>,Object> getScopedObjectMap(final Object origContext) {
+        Object context = origContext;
+        while( !(context instanceof RoboContext) && !(context instanceof Application) && context instanceof ContextWrapper )
+            context = ((ContextWrapper)context).getBaseContext();
+
+        // Special case for application so that users don't have to manually set up application subclasses
+        if( context instanceof Application )
+            return applicationScopedObjects;
+
+
+        if( !(context instanceof RoboContext) )
+            throw new IllegalArgumentException(String.format("%s does not appear to be a RoboGuice context (instanceof RoboContext)",origContext));
+
+        return ((RoboContext)context).getScopedObjectMap();
+    }
+}

--- a/roboguice/src/main/java/roboguice/inject/FragmentScopeProvider.java
+++ b/roboguice/src/main/java/roboguice/inject/FragmentScopeProvider.java
@@ -1,0 +1,14 @@
+package roboguice.inject;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+import android.app.Application;
+
+public class FragmentScopeProvider implements Provider<FragmentScope> {
+    @Inject protected Application application;
+
+    public FragmentScope get() {
+        return new FragmentScope(application);
+    }
+}

--- a/roboguice/src/main/java/roboguice/inject/FragmentScopedRoboInjector.java
+++ b/roboguice/src/main/java/roboguice/inject/FragmentScopedRoboInjector.java
@@ -1,0 +1,279 @@
+package roboguice.inject;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import roboguice.inject.ViewListener.ViewMembersInjector;
+
+import com.google.inject.Binding;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.MembersInjector;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.Scope;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.TypeConverterBinding;
+
+import android.app.Activity;
+import android.app.Fragment;
+
+public class FragmentScopedRoboInjector implements RoboInjector {
+    protected Injector delegate;
+    protected Object fragment;
+    protected FragmentScope scope;
+
+    public FragmentScopedRoboInjector(Object fragment, Injector activityInjector) {
+        this.delegate = activityInjector;
+        this.fragment = fragment;
+        this.scope = delegate.getInstance(FragmentScope.class);
+    }
+    
+    @Override
+    public Injector createChildInjector(Iterable<? extends Module> modules) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.createChildInjector(modules);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public Injector createChildInjector(Module... modules) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.createChildInjector(modules);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public <T> List<Binding<T>> findBindingsByType(TypeLiteral<T> type) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.findBindingsByType(type);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public Map<Key<?>, Binding<?>> getAllBindings() {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getAllBindings();
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public <T> Binding<T> getBinding(Key<T> key) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getBinding(key);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public <T> Binding<T> getBinding(Class<T> type) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getBinding(type);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public Map<Key<?>, Binding<?>> getBindings() {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getBindings();
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public <T> Binding<T> getExistingBinding(Key<T> key) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getExistingBinding(key);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public <T> T getInstance(Key<T> key) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getInstance(key);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public <T> T getInstance(Class<T> type) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getInstance(type);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public <T> MembersInjector<T> getMembersInjector(Class<T> type) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getMembersInjector(type);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public <T> MembersInjector<T> getMembersInjector(TypeLiteral<T> typeLiteral) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getMembersInjector(typeLiteral);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public Injector getParent() {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getParent();
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public <T> Provider<T> getProvider(Key<T> key) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getProvider(key);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public <T> Provider<T> getProvider(Class<T> type) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getProvider(type);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public Map<Class<? extends Annotation>, Scope> getScopeBindings() {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getScopeBindings();
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public Set<TypeConverterBinding> getTypeConverterBindings() {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                return delegate.getTypeConverterBindings();
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public void injectMembers(Object instance) {
+        injectMembersWithoutViews(instance);
+    }
+
+    public void injectMembersWithoutViews( Object instance ) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                delegate.injectMembers(instance);
+            }finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+
+    @Override
+    public void injectViewMembers(Activity activity) {
+        throw new UnsupportedOperationException("It is not possible to use a fragment injector to inject views into an activity. Use the activity injector.");
+    }
+
+    @Override
+    public void injectViewMembers(android.support.v4.app.Fragment fragment) {
+        injectViews(fragment);
+    }
+
+    @Override
+    public void injectViewMembers(Fragment fragment) {
+        injectViews(fragment);
+    }
+
+    private void injectViews(Object fragment) {
+        synchronized (FragmentScope.class) {
+            scope.enter(fragment);
+            try {
+                ViewMembersInjector.injectViews(fragment);
+            } finally {
+                scope.exit(fragment);
+            }
+        }
+    }
+}

--- a/roboguice/src/main/java/roboguice/inject/FragmentSingleton.java
+++ b/roboguice/src/main/java/roboguice/inject/FragmentSingleton.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2009 Michael Burton
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package roboguice.inject;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.google.inject.ScopeAnnotation;
+
+/**
+ * Apply this to implementation classes when you want one instance per fragment
+ * instance.
+ *
+ * @author SNI
+ */
+@Target( { TYPE, METHOD, FIELD })
+@Retention(RUNTIME)
+@ScopeAnnotation
+public @interface FragmentSingleton {
+}

--- a/roboguice/src/test/java/roboguice/fragment/FragmentInjectionTest.java
+++ b/roboguice/src/test/java/roboguice/fragment/FragmentInjectionTest.java
@@ -1,6 +1,7 @@
 package roboguice.fragment;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
@@ -11,6 +12,9 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.util.ActivityController;
 
 import roboguice.activity.RoboFragmentActivity;
+import roboguice.fragment.RoboFragment;
+import roboguice.inject.ContextSingleton;
+import roboguice.inject.FragmentSingleton;
 import roboguice.inject.InjectView;
 
 import com.google.inject.Inject;
@@ -85,7 +89,17 @@ public class FragmentInjectionTest {
         assertThat(activityD2.fragmentRef.v, equalTo(activityD2.fragmentRef.ref));
     }
 
+    @Test
+    public void shouldUseFragmentScopePerFragment() {
+        final ActivityE activityE = Robolectric.buildActivity(ActivityE.class).create().start().resume().get();
 
+        assertThat(activityE.fragmentRef1.foo, not(equalTo(activityE.fragmentRef2.foo)));
+        assertThat(activityE.fragmentRef1.bar, not(equalTo(activityE.fragmentRef2.bar)));
+        assertThat(activityE.fragmentRef1.qurtz, equalTo(activityE.fragmentRef2.qurtz));
+        assertThat(activityE.fragmentRef1.bar.foo, not(equalTo(activityE.fragmentRef2.bar.foo)));
+        assertThat(activityE.fragmentRef1.bar.foo, equalTo(activityE.fragmentRef1.foo));
+        assertThat(activityE.fragmentRef2.bar.foo, equalTo(activityE.fragmentRef2.foo));
+    }
 
     public static class ActivityA extends RoboFragmentActivity {
         FragmentA fragmentRef;
@@ -93,19 +107,13 @@ public class FragmentInjectionTest {
         @Override
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
-
-//            fragmentRef = new FragmentA();
-//            fragmentRef.onAttach(this);
-//            fragmentRef.onCreate(null);
             fragmentRef = new FragmentA();
             startFragment(this, fragmentRef);
-
         }
 
         public static class FragmentA extends RoboFragment {
             @InjectView(101) View v;
             @Inject Context context;
-
             View ref;
 
             @Override
@@ -115,33 +123,27 @@ public class FragmentInjectionTest {
                 return ref;
             }
         }
-
     }
 
 
     public static class ActivityB extends RoboFragmentActivity {
         @InjectView(100) View v;
-
         View viewRef;
         FragmentB fragmentRef;
 
         @Override
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
-
             viewRef =  new View(this);
             viewRef.setId(100);
             setContentView(viewRef);
-
             fragmentRef = new FragmentB();
             startFragment(this, fragmentRef);
         }
 
         public static class FragmentB extends RoboFragment {
             @InjectView(101) View v;
-
             View viewRef;
-
             @Override
             public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
                 viewRef = new View(getActivity());
@@ -149,12 +151,10 @@ public class FragmentInjectionTest {
                 return viewRef;
             }
         }
-
     }
 
     public static class ActivityC extends RoboFragmentActivity {
         @InjectView(101) View v;
-
         View viewRef;
         FragmentC fragmentRef;
 
@@ -162,14 +162,12 @@ public class FragmentInjectionTest {
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             setContentView( new View(this) );
-
             fragmentRef = new FragmentC();
             startFragment(this, fragmentRef);
         }
 
         public static class FragmentC extends RoboFragment {
             @InjectView(101) View v;
-
             View viewRef;
 
             @Override
@@ -179,10 +177,7 @@ public class FragmentInjectionTest {
                 return viewRef;
             }
         }
-
     }
-
-
 
     public static class ActivityD extends RoboFragmentActivity {
         FragmentD fragmentRef;
@@ -190,18 +185,13 @@ public class FragmentInjectionTest {
         @Override
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
-
             fragmentRef = new FragmentD();
             startFragment(this,fragmentRef);
-
-
             setContentView(new FrameLayout(this));
-            
         }
 
         public static class FragmentD extends RoboFragment {
             @InjectView(101) View v;
-
             View ref;
 
             @Override
@@ -211,7 +201,35 @@ public class FragmentInjectionTest {
                 return ref;
             }
         }
-
     }
 
+    public static class ActivityE extends RoboFragmentActivity {
+        FragmentE fragmentRef1;
+        FragmentE fragmentRef2;
+
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            fragmentRef1 = new FragmentE();
+            startFragment(this,fragmentRef1);
+            fragmentRef2 = new FragmentE();
+            startFragment(this,fragmentRef2);
+            setContentView(new FrameLayout(this));
+        }
+
+        public static class FragmentE extends RoboFragment {
+            @Inject Foo foo;
+            @Inject Bar bar;
+            @Inject Qurtz qurtz;
+        }
+        
+        @FragmentSingleton static class Foo {}
+        
+        static class Bar {
+            @Inject Foo foo;
+        }
+        
+        @ContextSingleton static class Qurtz {
+        }
+    }
 }

--- a/roboguice/src/test/java/roboguice/fragment/provided/FragmentInjectionTest.java
+++ b/roboguice/src/test/java/roboguice/fragment/provided/FragmentInjectionTest.java
@@ -1,6 +1,7 @@
 package roboguice.fragment.provided;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
@@ -12,6 +13,9 @@ import org.robolectric.annotation.Config;
 import org.robolectric.util.ActivityController;
 
 import roboguice.activity.RoboActivity;
+import roboguice.fragment.provided.RoboFragment;
+import roboguice.inject.ContextSingleton;
+import roboguice.inject.FragmentSingleton;
 import roboguice.inject.InjectView;
 
 import com.google.inject.Inject;
@@ -85,8 +89,18 @@ public class FragmentInjectionTest {
         assertNotNull(activity2.fragmentRef.ref);
         assertThat(activity2.fragmentRef.v, equalTo(activity2.fragmentRef.ref));
     }
+    
+    @Test
+    public void shouldUseFragmentScopePerFragment() {
+        final ActivityE activityE = Robolectric.buildActivity(ActivityE.class).create().start().resume().get();
 
-
+        assertThat(activityE.fragmentRef1.foo, not(equalTo(activityE.fragmentRef2.foo)));
+        assertThat(activityE.fragmentRef1.bar, not(equalTo(activityE.fragmentRef2.bar)));
+        assertThat(activityE.fragmentRef1.qurtz, equalTo(activityE.fragmentRef2.qurtz));
+        assertThat(activityE.fragmentRef1.bar.foo, not(equalTo(activityE.fragmentRef2.bar.foo)));
+        assertThat(activityE.fragmentRef1.bar.foo, equalTo(activityE.fragmentRef1.foo));
+        assertThat(activityE.fragmentRef2.bar.foo, equalTo(activityE.fragmentRef2.foo));
+    }
 
     public static class ActivityA extends RoboActivity {
         FragmentA fragmentRef;
@@ -94,28 +108,16 @@ public class FragmentInjectionTest {
         @Override
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
-
             fragmentRef = new FragmentA();
             fragmentRef.onAttach(this);
             fragmentRef.onCreate(null);
-
         }
 
         public static class FragmentA extends RoboFragment {
             @InjectView(101) View v;
             @Inject Context context;
-
             View ref;
 
-            @Override
-            public void onCreate(Bundle savedInstanceState) {
-                super.onCreate(savedInstanceState);
-            }
-            
-            @Override
-            public void onViewCreated(View view, Bundle savedInstanceState) {
-                super.onViewCreated(view, savedInstanceState);
-            }
             @Override
             public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
                 ref = new View(getActivity());
@@ -123,24 +125,19 @@ public class FragmentInjectionTest {
                 return ref;
             }
         }
-
     }
-
 
     public static class ActivityB extends RoboActivity {
         @InjectView(100) View v;
-
         View viewRef;
         FragmentB fragmentRef;
 
         @Override
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
-
             viewRef =  new View(this);
             viewRef.setId(100);
             setContentView(viewRef);
-
             fragmentRef = new FragmentB();
             fragmentRef.onAttach(this);
             fragmentRef.onCreate(null);
@@ -149,7 +146,6 @@ public class FragmentInjectionTest {
 
         public static class FragmentB extends RoboFragment {
             @InjectView(101) View v;
-
             View viewRef;
 
             @Override
@@ -159,12 +155,10 @@ public class FragmentInjectionTest {
                 return viewRef;
             }
         }
-
     }
 
     public static class ActivityC extends RoboActivity {
         @InjectView(101) View v;
-
         View viewRef;
         FragmentC fragmentRef;
 
@@ -172,8 +166,6 @@ public class FragmentInjectionTest {
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             setContentView( new View(this) );
-
-
             fragmentRef = new FragmentC();
             fragmentRef.onAttach(this);
             fragmentRef.onCreate(null);
@@ -182,7 +174,6 @@ public class FragmentInjectionTest {
 
         public static class FragmentC extends RoboFragment {
             @InjectView(101) View v;
-
             View viewRef;
 
             @Override
@@ -192,10 +183,7 @@ public class FragmentInjectionTest {
                 return viewRef;
             }
         }
-
     }
-
-
 
     public static class ActivityD extends RoboActivity {
         FragmentD fragmentRef;
@@ -203,28 +191,14 @@ public class FragmentInjectionTest {
         @Override
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
-
             fragmentRef = new FragmentD();
             fragmentRef.onAttach(this);
             fragmentRef.onCreate(null);
-
             setContentView(new FrameLayout(this));
-            
-        }
-
-        @Override
-        protected void onPause() {
-            super.onPause();
-        }
-
-        @Override
-        protected void onResume() {
-            super.onResume();
         }
 
         public static class FragmentD extends RoboFragment {
             @InjectView(101) View v;
-
             View ref;
 
             @Override
@@ -233,13 +207,39 @@ public class FragmentInjectionTest {
                 ref.setId(101);
                 return ref;
             }
+        }
+    }
+    
+    public static class ActivityE extends RoboActivity {
+        FragmentE fragmentRef1;
+        FragmentE fragmentRef2;
 
-            @Override
-            public void onCreate(Bundle savedInstanceState) {
-                super.onCreate(savedInstanceState);
-            }
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            fragmentRef1 = new FragmentE();
+            fragmentRef1.onAttach(this);
+            fragmentRef1.onCreate(null);
+            fragmentRef2 = new FragmentE();
+            fragmentRef2.onAttach(this);
+            fragmentRef2.onCreate(null);
+            setContentView(new FrameLayout(this));
         }
 
+        public static class FragmentE extends RoboFragment {
+            @Inject Foo foo;
+            @Inject Bar bar;
+            @Inject Qurtz qurtz;
+        }
+        
+        @FragmentSingleton static class Foo {}
+        
+        static class Bar {
+            @Inject Foo foo;
+        }
+        
+        @ContextSingleton static class Qurtz {
+        }
     }
 
 }

--- a/roboguice/src/test/java/roboguice/view/ViewInjectionTest.java
+++ b/roboguice/src/test/java/roboguice/view/ViewInjectionTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 import java.lang.ref.SoftReference;
 import java.util.ArrayList;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -79,9 +78,6 @@ public class ViewInjectionTest {
 
     }
 
-
-
-    @Ignore("getWindow().getDecoreView() doesn't seem to return the root view in robolectric?")
     @Test
     public void shouldBeAbleToInjectReferencesToTaggedViews() {
         final D activity = Robolectric.buildActivity(D.class).create().get();


### PR DESCRIPTION
Work on  https://github.com/roboguice/roboguice/issues/146

This implementation provides a fragment scope. The fragment injector is always a child of its activity injector (which is child of the application injector). 

For more details on nested fragments, please read below.

---
#### Nested fragments.

It would be very nice if the injector of an inner fragment could be a child injector of its parent's injector. 

This looks logical. Nevertheless, it looks like there is no way to know the parent Fragment of a subFragment before API 17.
http://developer.android.com/reference/android/app/Fragment.html#getParentFragment()

I highlight a couple of StackOverFlow questions and answers on this matter : 
- [How to get all sub/inner/nested Fragments of a Fragment?](http://stackoverflow.com/q/24315576/693752)
- [Is there a way to get references for all currently active fragments in an Activity?](http://stackoverflow.com/q/6102007/693752)
- [getParentFragment API 16](http://stackoverflow.com/q/20376297/693752)

Please not that there is absolutely no problem to get the parent fragment of a fragment when using latest versions of the support library : http://developer.android.com/reference/android/support/v4/app/Fragment.html#getParentFragment()
