### PR TITLE
To avoid using a hack context provider... ;)

### DIFF
--- a/roboguice/src/main/java/roboguice/config/DefaultRoboModule.java
+++ b/roboguice/src/main/java/roboguice/config/DefaultRoboModule.java
@@ -146,7 +146,8 @@ public class DefaultRoboModule extends AbstractModule {
 
         // ContextSingleton bindings
         bindScope(ContextSingleton.class, contextScope);
-        bind(ContextScope.class).toInstance(contextScope);
+        //we need to super bind as we inject the scope by code only, not by annotations
+        superbind(ContextScope.class).toInstance(contextScope);
         bind(AssetManager.class).toProvider(AssetManagerProvider.class);
         bind(Context.class).toProvider(NullProvider.<Context>instance()).in(ContextSingleton.class);
         bind(Activity.class).toProvider(NullProvider.<Activity>instance()).in(ContextSingleton.class);

--- a/roboguice/src/main/java/roboguice/inject/ContextScopedProvider.java
+++ b/roboguice/src/main/java/roboguice/inject/ContextScopedProvider.java
@@ -1,5 +1,7 @@
 package roboguice.inject;
 
+import roboguice.RoboGuice;
+
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -7,10 +9,11 @@ import android.content.Context;
 
 
 public class ContextScopedProvider<T> {
-    @Inject protected ContextScope scope;
     @Inject protected Provider<T> provider;
 
     public T get(Context context) {
+        //see https://github.com/roboguice/roboguice/issues/112
+        final ContextScope scope = RoboGuice.getInjector(context).getInstance(ContextScope.class);
         synchronized (ContextScope.class) {
             scope.enter(context);
             try {

--- a/roboguice/src/test/java/roboguice/view/ViewInjectionTest.java
+++ b/roboguice/src/test/java/roboguice/view/ViewInjectionTest.java
@@ -28,7 +28,7 @@ import android.widget.LinearLayout;
 
 @RunWith(RobolectricTestRunner.class)
 public class ViewInjectionTest {
-
+    
     @Test
     public void shouldInjectViewsIntoActivitiesAndViews() {
         final C activity = Robolectric.buildActivity(C.class).create().get();


### PR DESCRIPTION
Solves a bug in context provider as current context may not be the desired context owning the scope of the desired injected instance.
