### PR TITLE
issue #110. Missing Roboguice events for Fragment.onViewCreated, onCreate, etc.

### DIFF
--- a/roboguice/src/main/java/roboguice/fragment/RoboDialogFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/RoboDialogFragment.java
@@ -1,26 +1,107 @@
 package roboguice.fragment;
 
+import android.app.Activity;
+import android.content.res.Configuration;
+import com.google.inject.Inject;
 import roboguice.RoboGuice;
 
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.view.View;
+import roboguice.event.EventManager;
+import roboguice.fragment.event.OnActivityCreatedEvent;
+import roboguice.fragment.event.OnAttachEvent;
+import roboguice.fragment.event.OnConfigurationChangedEvent;
+import roboguice.fragment.event.OnCreateEvent;
+import roboguice.fragment.event.OnDestroyEvent;
+import roboguice.fragment.event.OnDetachEvent;
+import roboguice.fragment.event.OnPauseEvent;
+import roboguice.fragment.event.OnResumeEvent;
+import roboguice.fragment.event.OnStartEvent;
+import roboguice.fragment.event.OnStopEvent;
+import roboguice.fragment.event.OnViewCreatedEvent;
 
 /**
  * Provides an injected {@link DialogFragment} based on support library v4.
- * A RoboDialogFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}. 
+ * A RoboDialogFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}.
  * @author Michael Burton
  */
 public abstract class RoboDialogFragment extends DialogFragment {
+    @Inject
+    protected EventManager eventManager;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnCreateEvent(this, savedInstanceState));
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        eventManager.fire(new OnViewCreatedEvent(this, view, savedInstanceState));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent(this, currentConfig, newConfig));
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        eventManager.fire(new OnActivityCreatedEvent(this, savedInstanceState));
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnAttachEvent(this, activity));
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        eventManager.fire(new OnDetachEvent(this));
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent(this));
+        } finally {
+            super.onDestroy();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent(this));
+    }
+
+    @Override
+    public void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent(this));
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent(this));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent(this));
     }
 }

--- a/roboguice/src/main/java/roboguice/fragment/RoboFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/RoboFragment.java
@@ -1,26 +1,107 @@
 package roboguice.fragment;
 
+import android.app.Activity;
+import android.content.res.Configuration;
+import com.google.inject.Inject;
 import roboguice.RoboGuice;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.View;
+import roboguice.event.EventManager;
+import roboguice.fragment.event.OnActivityCreatedEvent;
+import roboguice.fragment.event.OnAttachEvent;
+import roboguice.fragment.event.OnConfigurationChangedEvent;
+import roboguice.fragment.event.OnCreateEvent;
+import roboguice.fragment.event.OnDestroyEvent;
+import roboguice.fragment.event.OnDetachEvent;
+import roboguice.fragment.event.OnPauseEvent;
+import roboguice.fragment.event.OnResumeEvent;
+import roboguice.fragment.event.OnStartEvent;
+import roboguice.fragment.event.OnStopEvent;
+import roboguice.fragment.event.OnViewCreatedEvent;
 
 /**
  * Provides an injected {@link Fragment} based on support library v4.
- * A RoboFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}. 
+ * A RoboFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}.
  * @author Michael Burton
  */
 public abstract class RoboFragment extends Fragment {
+    @Inject
+    protected EventManager eventManager;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnCreateEvent(this, savedInstanceState));
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        eventManager.fire(new OnViewCreatedEvent(this, view, savedInstanceState));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent(this, currentConfig, newConfig));
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        eventManager.fire(new OnActivityCreatedEvent(this, savedInstanceState));
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnAttachEvent(this, activity));
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        eventManager.fire(new OnDetachEvent(this));
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent(this));
+        } finally {
+            super.onDestroy();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent(this));
+    }
+
+    @Override
+    public void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent(this));
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent(this));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent(this));
     }
 }

--- a/roboguice/src/main/java/roboguice/fragment/RoboListFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/RoboListFragment.java
@@ -1,26 +1,107 @@
 package roboguice.fragment;
 
+import android.app.Activity;
+import android.content.res.Configuration;
+import com.google.inject.Inject;
 import roboguice.RoboGuice;
 
 import android.os.Bundle;
 import android.support.v4.app.ListFragment;
 import android.view.View;
+import roboguice.event.EventManager;
+import roboguice.fragment.event.OnActivityCreatedEvent;
+import roboguice.fragment.event.OnAttachEvent;
+import roboguice.fragment.event.OnConfigurationChangedEvent;
+import roboguice.fragment.event.OnCreateEvent;
+import roboguice.fragment.event.OnDestroyEvent;
+import roboguice.fragment.event.OnDetachEvent;
+import roboguice.fragment.event.OnPauseEvent;
+import roboguice.fragment.event.OnResumeEvent;
+import roboguice.fragment.event.OnStartEvent;
+import roboguice.fragment.event.OnStopEvent;
+import roboguice.fragment.event.OnViewCreatedEvent;
 
 /**
  * Provides an injected {@link ListFragment} based on support library v4.
- * A RoboListFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}. 
+ * A RoboListFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}.
  * @author Michael Burton
  */
 public abstract class RoboListFragment extends ListFragment {
+    @Inject
+    protected EventManager eventManager;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnCreateEvent(this, savedInstanceState));
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        eventManager.fire(new OnViewCreatedEvent(this, view, savedInstanceState));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent(this, currentConfig, newConfig));
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        eventManager.fire(new OnActivityCreatedEvent(this, savedInstanceState));
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnAttachEvent(this, activity));
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        eventManager.fire(new OnDetachEvent(this));
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent(this));
+        } finally {
+            super.onDestroy();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent(this));
+    }
+
+    @Override
+    public void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent(this));
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent(this));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent(this));
     }
 }

--- a/roboguice/src/main/java/roboguice/fragment/RoboSherlockDialogFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/RoboSherlockDialogFragment.java
@@ -1,27 +1,108 @@
 package roboguice.fragment;
 
+import android.app.Activity;
+import android.content.res.Configuration;
+import com.google.inject.Inject;
 import roboguice.RoboGuice;
 
 import com.actionbarsherlock.app.SherlockDialogFragment;
 
 import android.os.Bundle;
 import android.view.View;
+import roboguice.event.EventManager;
+import roboguice.fragment.event.OnActivityCreatedEvent;
+import roboguice.fragment.event.OnAttachEvent;
+import roboguice.fragment.event.OnConfigurationChangedEvent;
+import roboguice.fragment.event.OnCreateEvent;
+import roboguice.fragment.event.OnDestroyEvent;
+import roboguice.fragment.event.OnDetachEvent;
+import roboguice.fragment.event.OnPauseEvent;
+import roboguice.fragment.event.OnResumeEvent;
+import roboguice.fragment.event.OnStartEvent;
+import roboguice.fragment.event.OnStopEvent;
+import roboguice.fragment.event.OnViewCreatedEvent;
 
 /**
  * Provides an injected {@link SherlockDialogFragment} based on ActionBarSherlock's Dialog Fragments.
- * A RoboSherlockDialogFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}. 
+ * A RoboSherlockDialogFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}.
  * @author Michael Burton
  */
 public abstract class RoboSherlockDialogFragment extends SherlockDialogFragment {
+    @Inject
+    protected EventManager eventManager;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnCreateEvent(this, savedInstanceState));
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        eventManager.fire(new OnViewCreatedEvent(this, view, savedInstanceState));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent(this, currentConfig, newConfig));
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        eventManager.fire(new OnActivityCreatedEvent(this, savedInstanceState));
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        eventManager.fire(new OnAttachEvent(this, activity));
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnDetachEvent(this));
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent(this));
+        } finally {
+            super.onDestroy();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent(this));
+    }
+
+    @Override
+    public void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent(this));
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent(this));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent(this));
     }
 }

--- a/roboguice/src/main/java/roboguice/fragment/RoboSherlockFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/RoboSherlockFragment.java
@@ -1,27 +1,108 @@
 package roboguice.fragment;
 
+import android.app.Activity;
+import android.content.res.Configuration;
+import com.google.inject.Inject;
 import roboguice.RoboGuice;
 
 import com.actionbarsherlock.app.SherlockFragment;
 
 import android.os.Bundle;
 import android.view.View;
+import roboguice.event.EventManager;
+import roboguice.fragment.event.OnActivityCreatedEvent;
+import roboguice.fragment.event.OnAttachEvent;
+import roboguice.fragment.event.OnConfigurationChangedEvent;
+import roboguice.fragment.event.OnCreateEvent;
+import roboguice.fragment.event.OnDestroyEvent;
+import roboguice.fragment.event.OnDetachEvent;
+import roboguice.fragment.event.OnPauseEvent;
+import roboguice.fragment.event.OnResumeEvent;
+import roboguice.fragment.event.OnStartEvent;
+import roboguice.fragment.event.OnStopEvent;
+import roboguice.fragment.event.OnViewCreatedEvent;
 
 /**
  * Provides an injected {@link SherlockFragment} based on ActionBarSherlock's Fragments.
- * A RoboSherlockFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}. 
+ * A RoboSherlockFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}.
  * @author Michael Burton
  */
 public abstract class RoboSherlockFragment extends SherlockFragment {
+    @Inject
+    protected EventManager eventManager;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnCreateEvent(this, savedInstanceState));
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        eventManager.fire(new OnViewCreatedEvent(this, view, savedInstanceState));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent(this, currentConfig, newConfig));
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        eventManager.fire(new OnActivityCreatedEvent(this, savedInstanceState));
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnAttachEvent(this, activity));
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        eventManager.fire(new OnDetachEvent(this));
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent(this));
+        } finally {
+            super.onDestroy();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent(this));
+    }
+
+    @Override
+    public void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent(this));
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent(this));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent(this));
     }
 }

--- a/roboguice/src/main/java/roboguice/fragment/RoboSherlockListFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/RoboSherlockListFragment.java
@@ -1,27 +1,108 @@
 package roboguice.fragment;
 
+import android.app.Activity;
+import android.content.res.Configuration;
+import com.google.inject.Inject;
 import roboguice.RoboGuice;
 
 import com.actionbarsherlock.app.SherlockListFragment;
 
 import android.os.Bundle;
 import android.view.View;
+import roboguice.event.EventManager;
+import roboguice.fragment.event.OnActivityCreatedEvent;
+import roboguice.fragment.event.OnAttachEvent;
+import roboguice.fragment.event.OnConfigurationChangedEvent;
+import roboguice.fragment.event.OnCreateEvent;
+import roboguice.fragment.event.OnDestroyEvent;
+import roboguice.fragment.event.OnDetachEvent;
+import roboguice.fragment.event.OnPauseEvent;
+import roboguice.fragment.event.OnResumeEvent;
+import roboguice.fragment.event.OnStartEvent;
+import roboguice.fragment.event.OnStopEvent;
+import roboguice.fragment.event.OnViewCreatedEvent;
 
 /**
  * Provides an injected {@link SherlockListFragment} based on ActionBarSherlock's Fragments.
- * A RoboSherlockListFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}. 
+ * A RoboSherlockListFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}.
  * @author Michael Burton
  */
 public abstract class RoboSherlockListFragment extends SherlockListFragment {
+    @Inject
+    protected EventManager eventManager;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnCreateEvent(this, savedInstanceState));
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        eventManager.fire(new OnViewCreatedEvent(this, view, savedInstanceState));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent(this, currentConfig, newConfig));
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        eventManager.fire(new OnActivityCreatedEvent(this, savedInstanceState));
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnAttachEvent(this, activity));
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        eventManager.fire(new OnDetachEvent(this));
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent(this));
+        } finally {
+            super.onDestroy();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent(this));
+    }
+
+    @Override
+    public void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent(this));
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent(this));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent(this));
     }
 }

--- a/roboguice/src/main/java/roboguice/fragment/event/AbstractFragmentEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/AbstractFragmentEvent.java
@@ -1,0 +1,13 @@
+package roboguice.fragment.event;
+
+public abstract class AbstractFragmentEvent<T> {
+    protected final T fragment;
+
+    public AbstractFragmentEvent(T fragment) {
+        this.fragment = fragment;
+    }
+
+    public T getFragment() {
+        return fragment;
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/event/OnActivityCreatedEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnActivityCreatedEvent.java
@@ -1,0 +1,22 @@
+package roboguice.fragment.event;
+
+import android.os.Bundle;
+
+/**
+ * Class representing the event raised by RoboFragment.onActivityCreated()
+ *
+ * @author Cherry Development
+ */
+public class OnActivityCreatedEvent<T> extends AbstractFragmentEvent<T> {
+
+    protected final Bundle savedInstanceState;
+
+    public OnActivityCreatedEvent(T fragment, Bundle savedInstanceState) {
+        super(fragment);
+        this.savedInstanceState = savedInstanceState;
+    }
+
+    public Bundle getSavedInstanceState() {
+        return savedInstanceState;
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/event/OnAttachEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnAttachEvent.java
@@ -1,0 +1,23 @@
+package roboguice.fragment.event;
+
+import android.app.Activity;
+
+/**
+ * Class representing the event raised by RoboFragment.onAttach()
+ *
+ * @author Cherry Development
+ */
+public class OnAttachEvent<T> extends AbstractFragmentEvent<T> {
+
+    protected final Activity activity;
+
+    public OnAttachEvent(T fragment, Activity activity) {
+        super(fragment);
+        this.activity = activity;
+    }
+
+    public Activity getActivity() {
+        return activity;
+    }
+}
+

--- a/roboguice/src/main/java/roboguice/fragment/event/OnConfigurationChangedEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnConfigurationChangedEvent.java
@@ -1,0 +1,30 @@
+package roboguice.fragment.event;
+
+import android.content.res.Configuration;
+
+/**
+ * Class representing the event raised by RoboFragment.onConfigurationChanged()
+ *
+ * @author Adam Tybor
+ * @author John Ericksen
+ * @author Cherry Development
+ */
+public class OnConfigurationChangedEvent<T> extends AbstractFragmentEvent<T> {
+
+    protected Configuration oldConfig;
+    protected Configuration newConfig;
+
+    public OnConfigurationChangedEvent(T fragment, Configuration oldConfig, Configuration newConfig) {
+        super(fragment);
+        this.oldConfig = oldConfig;
+        this.newConfig = newConfig;
+    }
+
+    public Configuration getOldConfig() {
+        return oldConfig;
+    }
+
+    public Configuration getNewConfig() {
+        return newConfig;
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/event/OnCreateEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnCreateEvent.java
@@ -1,0 +1,26 @@
+package roboguice.fragment.event;
+
+import android.os.Bundle;
+
+/**
+ * Class representing the event raised by RoboFragment.onCreate()
+ *
+ * You may also be interested in roboguice.fragment.provided.event.OnViewCreatedEvent
+ *
+ * @author Adam Tybor
+ * @author John Ericksen
+ * @author Cherry Development
+ */
+public class OnCreateEvent<T> extends AbstractFragmentEvent<T> {
+
+    protected Bundle savedInstanceState;
+
+    public OnCreateEvent(T fragment, Bundle savedInstanceState) {
+        super(fragment);
+        this.savedInstanceState = savedInstanceState;
+    }
+
+    public Bundle getSavedInstanceState() {
+        return savedInstanceState;
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/event/OnDestroyEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnDestroyEvent.java
@@ -1,0 +1,15 @@
+package roboguice.fragment.event;
+
+/**
+ * Class representing the event raised by RoboFragment.onDestroy()
+ *
+ * @author Adam Tybor
+ * @author John Ericksen
+ * @author Cherry Development
+ */
+public class OnDestroyEvent<T> extends AbstractFragmentEvent<T> {
+
+    public OnDestroyEvent(T fragment) {
+        super(fragment);
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/event/OnDetachEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnDetachEvent.java
@@ -1,0 +1,15 @@
+package roboguice.fragment.event;
+
+/**
+ * Class representing the event raised by RoboFragment.onDetach()
+ *
+ * @author Adam Tybor
+ * @author John Ericksen
+ * @author Cherry Development
+ */
+public class OnDetachEvent<T> extends AbstractFragmentEvent<T> {
+
+    public OnDetachEvent(T fragment) {
+        super(fragment);
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/event/OnPauseEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnPauseEvent.java
@@ -1,0 +1,15 @@
+package roboguice.fragment.event;
+
+/**
+ * Class representing the event raised by RoboFragment.onPause()
+ *
+ * @author Adam Tybor
+ * @author John Ericksen
+ * @author Cherry Development
+ */
+public class OnPauseEvent<T> extends AbstractFragmentEvent<T> {
+
+    public OnPauseEvent(T fragment) {
+        super(fragment);
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/event/OnRestartEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnRestartEvent.java
@@ -1,0 +1,15 @@
+package roboguice.fragment.event;
+
+/**
+ * Class representing the event raised by RoboFragment.onRestart()
+ *
+ * @author Adam Tybor
+ * @author John Ericksen
+ * @author Cherry Development
+ */
+public class OnRestartEvent<T> extends AbstractFragmentEvent<T> {
+
+    public OnRestartEvent(T fragment) {
+        super(fragment);
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/event/OnResumeEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnResumeEvent.java
@@ -1,0 +1,15 @@
+package roboguice.fragment.event;
+
+/**
+ * Class representing the event raised by RoboFragment.onResume()
+ *
+ * @author Adam Tybor
+ * @author John Ericksen
+ * @author Cherry Development
+ */
+public class OnResumeEvent<T> extends AbstractFragmentEvent<T> {
+
+    public OnResumeEvent(T fragment) {
+        super(fragment);
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/event/OnStartEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnStartEvent.java
@@ -1,0 +1,15 @@
+package roboguice.fragment.event;
+
+/**
+ * Class representing the event raised by RoboFragment.onStart()
+ *
+ * @author Adam Tybor
+ * @author John Ericksen
+ * @author Cherry Development
+ */
+public class OnStartEvent<T> extends AbstractFragmentEvent<T> {
+
+    public OnStartEvent(T fragment) {
+        super(fragment);
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/event/OnStopEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnStopEvent.java
@@ -1,0 +1,15 @@
+package roboguice.fragment.event;
+
+/**
+ * Class representing the event raised by RoboFragment.onStop()
+ *
+ * @author Adam Tybor
+ * @author John Ericksen
+ * @author Cherry Development
+ */
+public class OnStopEvent<T> extends AbstractFragmentEvent<T> {
+
+    public OnStopEvent(T fragment) {
+        super(fragment);
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/event/OnViewCreatedEvent.java
+++ b/roboguice/src/main/java/roboguice/fragment/event/OnViewCreatedEvent.java
@@ -1,0 +1,29 @@
+package roboguice.fragment.event;
+
+import android.os.Bundle;
+import android.view.View;
+
+/**
+ * Class representing the event raised by RoboFragment.onViewCreated()
+ *
+ * @author Cherry Development
+ */
+public class OnViewCreatedEvent<T> extends AbstractFragmentEvent<T> {
+
+    protected final View view;
+    protected final Bundle savedInstanceState;
+
+    public OnViewCreatedEvent(T fragment, View view, Bundle savedInstanceState) {
+        super(fragment);
+        this.view = view;
+        this.savedInstanceState = savedInstanceState;
+    }
+
+    public View getView() {
+        return view;
+    }
+
+    public Bundle getSavedInstanceState() {
+        return savedInstanceState;
+    }
+}

--- a/roboguice/src/main/java/roboguice/fragment/provided/RoboDialogFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/provided/RoboDialogFragment.java
@@ -1,29 +1,112 @@
 package roboguice.fragment.provided;
 
+import android.app.Activity;
+import android.content.res.Configuration;
+import com.google.inject.Inject;
 import roboguice.RoboGuice;
 
 import android.annotation.TargetApi;
 import android.app.DialogFragment;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
+import roboguice.event.EventManager;
+import roboguice.fragment.event.OnActivityCreatedEvent;
+import roboguice.fragment.event.OnAttachEvent;
+import roboguice.fragment.event.OnConfigurationChangedEvent;
+import roboguice.fragment.event.OnCreateEvent;
+import roboguice.fragment.event.OnDestroyEvent;
+import roboguice.fragment.event.OnDetachEvent;
+import roboguice.fragment.event.OnPauseEvent;
+import roboguice.fragment.event.OnResumeEvent;
+import roboguice.fragment.event.OnStartEvent;
+import roboguice.fragment.event.OnStopEvent;
+import roboguice.fragment.event.OnViewCreatedEvent;
+
+import static android.os.Build.VERSION_CODES.HONEYCOMB;
 
 /**
  * Provides an injected {@link DialogFragment} based on the native HONEY_COMB+ Fragments.
- * A RoboDialogFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}. 
+ * A RoboDialogFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}.
  * @author Charles Munger
  */
-@TargetApi(Build.VERSION_CODES.HONEYCOMB)
+@TargetApi(HONEYCOMB)
 public abstract class RoboDialogFragment extends DialogFragment {
+
+    @Inject
+    protected EventManager eventManager;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnCreateEvent(this, savedInstanceState));
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        eventManager.fire(new OnViewCreatedEvent(this, view, savedInstanceState));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent(this, currentConfig, newConfig));
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        eventManager.fire(new OnActivityCreatedEvent(this, savedInstanceState));
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnAttachEvent(this, activity));
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        eventManager.fire(new OnDetachEvent(this));
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent(this));
+        } finally {
+            super.onDestroy();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent(this));
+    }
+
+    @Override
+    public void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent(this));
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent(this));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent(this));
     }
 }

--- a/roboguice/src/main/java/roboguice/fragment/provided/RoboFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/provided/RoboFragment.java
@@ -1,29 +1,112 @@
 package roboguice.fragment.provided;
 
-import roboguice.RoboGuice;
-
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.app.Fragment;
-import android.os.Build;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.View;
+import com.google.inject.Inject;
+import roboguice.RoboGuice;
+import roboguice.event.EventManager;
+import roboguice.fragment.event.OnActivityCreatedEvent;
+import roboguice.fragment.event.OnAttachEvent;
+import roboguice.fragment.event.OnConfigurationChangedEvent;
+import roboguice.fragment.event.OnCreateEvent;
+import roboguice.fragment.event.OnDestroyEvent;
+import roboguice.fragment.event.OnDetachEvent;
+import roboguice.fragment.event.OnPauseEvent;
+import roboguice.fragment.event.OnResumeEvent;
+import roboguice.fragment.event.OnStartEvent;
+import roboguice.fragment.event.OnStopEvent;
+import roboguice.fragment.event.OnViewCreatedEvent;
+
+import static android.os.Build.VERSION_CODES.HONEYCOMB;
 
 /**
  * Provides an injected {@link Fragment} based on the native HONEY_COMB+ fragments.
- * A RoboFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}. 
+ * A RoboFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}.
+ *
  * @author Charles Munger
  */
-@TargetApi(Build.VERSION_CODES.HONEYCOMB) 
+@TargetApi(HONEYCOMB)
 public abstract class RoboFragment extends Fragment {
+
+    @Inject
+    protected EventManager eventManager;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnCreateEvent(this, savedInstanceState));
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        eventManager.fire(new OnViewCreatedEvent(this, view, savedInstanceState));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent(this, currentConfig, newConfig));
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        eventManager.fire(new OnActivityCreatedEvent(this, savedInstanceState));
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        RoboGuice.getInjector(activity).injectMembersWithoutViews(this);
+        eventManager.fire(new OnAttachEvent(this, activity));
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        eventManager.fire(new OnDetachEvent(this));
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent(this));
+        } finally {
+            super.onDestroy();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent(this));
+    }
+
+    @Override
+    public void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent(this));
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent(this));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent(this));
     }
 }

--- a/roboguice/src/main/java/roboguice/fragment/provided/RoboListFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/provided/RoboListFragment.java
@@ -1,29 +1,113 @@
 package roboguice.fragment.provided;
 
+import android.app.Activity;
+import android.content.res.Configuration;
+import com.google.inject.Inject;
 import roboguice.RoboGuice;
 
 import android.annotation.TargetApi;
 import android.app.ListFragment;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
+import roboguice.event.EventManager;
+import roboguice.fragment.event.OnActivityCreatedEvent;
+import roboguice.fragment.event.OnAttachEvent;
+import roboguice.fragment.event.OnConfigurationChangedEvent;
+import roboguice.fragment.event.OnCreateEvent;
+import roboguice.fragment.event.OnDestroyEvent;
+import roboguice.fragment.event.OnDetachEvent;
+import roboguice.fragment.event.OnPauseEvent;
+import roboguice.fragment.event.OnResumeEvent;
+import roboguice.fragment.event.OnStartEvent;
+import roboguice.fragment.event.OnStopEvent;
+import roboguice.fragment.event.OnViewCreatedEvent;
+
+import static android.os.Build.VERSION_CODES.HONEYCOMB;
 
 /**
  * Provides an injected {@link ListFragment} based on the native HONEY_COMB+ fragments.
- * A RoboListFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}. 
+ * A RoboListFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}.
  * @author Charles Munger
  */
-@TargetApi(Build.VERSION_CODES.HONEYCOMB) 
+@TargetApi(HONEYCOMB)
 public abstract class RoboListFragment extends ListFragment {
+
+    @Inject
+    protected EventManager eventManager;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnCreateEvent(this, savedInstanceState));
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        eventManager.fire(new OnViewCreatedEvent(this, view, savedInstanceState));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent(this, currentConfig, newConfig));
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        eventManager.fire(new OnActivityCreatedEvent(this, savedInstanceState));
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnAttachEvent(this, activity));
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        eventManager.fire(new OnDetachEvent(this));
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent(this));
+        } finally {
+            super.onDestroy();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent(this));
+    }
+
+    @Override
+    public void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent(this));
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent(this));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent(this));
     }
 }
+

--- a/roboguice/src/main/java/roboguice/fragment/provided/RoboPreferenceFragment.java
+++ b/roboguice/src/main/java/roboguice/fragment/provided/RoboPreferenceFragment.java
@@ -1,29 +1,112 @@
 package roboguice.fragment.provided;
 
+import android.app.Activity;
+import android.content.res.Configuration;
+import com.google.inject.Inject;
 import roboguice.RoboGuice;
 
 import android.annotation.TargetApi;
-import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceFragment;
 import android.view.View;
+import roboguice.event.EventManager;
+import roboguice.fragment.event.OnActivityCreatedEvent;
+import roboguice.fragment.event.OnAttachEvent;
+import roboguice.fragment.event.OnConfigurationChangedEvent;
+import roboguice.fragment.event.OnCreateEvent;
+import roboguice.fragment.event.OnDestroyEvent;
+import roboguice.fragment.event.OnDetachEvent;
+import roboguice.fragment.event.OnPauseEvent;
+import roboguice.fragment.event.OnResumeEvent;
+import roboguice.fragment.event.OnStartEvent;
+import roboguice.fragment.event.OnStopEvent;
+import roboguice.fragment.event.OnViewCreatedEvent;
+
+import static android.os.Build.VERSION_CODES.HONEYCOMB;
 
 /**
  * Provides an injected {@link PreferenceFragment} based on the native HONEY_COMB+ fragments.
- * A RoboPreferenceFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}. 
+ * A RoboPreferenceFragment will see all its members and views injected after {@link #onViewCreated(View, Bundle)}.
  * @author SNI
  */
-@TargetApi(Build.VERSION_CODES.HONEYCOMB) 
+@TargetApi(HONEYCOMB)
 public abstract class RoboPreferenceFragment extends PreferenceFragment {
+
+    @Inject
+    protected EventManager eventManager;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnCreateEvent(this, savedInstanceState));
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         RoboGuice.getInjector(getActivity()).injectViewMembers(this);
+        eventManager.fire(new OnViewCreatedEvent(this, view, savedInstanceState));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        final Configuration currentConfig = getResources().getConfiguration();
+        super.onConfigurationChanged(newConfig);
+        eventManager.fire(new OnConfigurationChangedEvent(this, currentConfig, newConfig));
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        eventManager.fire(new OnActivityCreatedEvent(this, savedInstanceState));
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        RoboGuice.getInjector(getActivity()).injectMembersWithoutViews(this);
+        eventManager.fire(new OnAttachEvent(this, activity));
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        eventManager.fire(new OnDetachEvent(this));
+    }
+
+    @Override
+    public void onDestroy() {
+        try {
+            eventManager.fire(new OnDestroyEvent(this));
+        } finally {
+            super.onDestroy();
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        eventManager.fire(new OnStartEvent(this));
+    }
+
+    @Override
+    public void onStop() {
+        try {
+            eventManager.fire(new OnStopEvent(this));
+        } finally {
+            super.onStop();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        eventManager.fire(new OnResumeEvent(this));
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        eventManager.fire(new OnPauseEvent(this));
     }
 }

--- a/roboguice/src/test/java/roboguice/fragment/FragmentEventInjectionTest.java
+++ b/roboguice/src/test/java/roboguice/fragment/FragmentEventInjectionTest.java
@@ -1,0 +1,121 @@
+package roboguice.fragment;
+
+import android.annotation.TargetApi;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import com.google.inject.AbstractModule;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.util.ActivityController;
+import roboguice.RoboGuice;
+import roboguice.activity.RoboFragmentActivity;
+import roboguice.event.EventManager;
+
+import static android.os.Build.VERSION_CODES.HONEYCOMB;
+
+//TODO : this could be made easier when switching to Robolectric 2.3
+@RunWith(RobolectricTestRunner.class)
+public class FragmentEventInjectionTest {
+
+    private EventManager eventManager = EasyMock.createMock(EventManager.class);
+
+    @Before
+    public void setup() {
+        RoboGuice.overrideApplicationInjector(Robolectric.application, new EventTestModule());
+    }
+
+    //http://blog.nikhaldimann.com/2013/10/10/robolectric-2-2-some-pages-from-the-missing-manual/
+    //http://stackoverflow.com/questions/11333354/how-can-i-test-fragments-with-robolectric
+    @TargetApi(HONEYCOMB)
+    @Test
+    public void testShouldReceiveEvents() {
+        //GIVEN
+        eventManager.registerObserver((Class) EasyMock.anyObject(), (roboguice.event.EventListener<?>) EasyMock.anyObject());
+        //try to keep FQN to see what belongs to activity and fragment
+        eventManager.fire(EasyMock.isA(roboguice.context.event.OnCreateEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.activity.event.OnContentChangedEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnAttachEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnCreateEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnActivityCreatedEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnViewCreatedEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.context.event.OnStartEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnStartEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.activity.event.OnResumeEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnResumeEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.activity.event.OnPauseEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnPauseEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.activity.event.OnStopEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnStopEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.context.event.OnDestroyEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnDestroyEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnDetachEvent.class));
+        eventManager.destroy();
+
+        EasyMock.replay(eventManager);
+
+        //WHEN
+        final ActivityController<ActivityEvent> activityController = Robolectric.buildActivity(ActivityEvent.class);
+
+        final ActivityEvent activity = activityController.get();
+        activityController.create();
+        activityController.postCreate(null);
+        activityController.start();
+        activityController.resume();
+        activityController.postResume();
+        activityController.visible();
+        startFragment(activity, activity.fragmentRef, ActivityEvent.CONTAINER_ID);
+        activityController.pause();
+        activityController.stop();
+        activityController.destroy();
+
+        //THEN
+        EasyMock.verify(eventManager);
+    }
+
+    public static class ActivityEvent extends RoboFragmentActivity {
+        public static final int CONTAINER_ID = 1;
+        FragmentEvent fragmentRef;
+
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            LinearLayout view = new LinearLayout(this);
+            view.setId(CONTAINER_ID);
+
+            setContentView(view);
+
+            fragmentRef = new FragmentEvent();
+        }
+
+        public static class FragmentEvent extends RoboFragment {
+
+            @Override
+            public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+                return new View(inflater.getContext());
+            }
+        }
+    }
+
+    // http://stackoverflow.com/questions/11333354/how-can-i-test-fragments-with-robolectric
+    protected static void startFragment(FragmentActivity activity, Fragment fragment, int containerId) {
+        final android.support.v4.app.FragmentManager fragmentManager = activity.getSupportFragmentManager();
+        final android.support.v4.app.FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+        fragmentTransaction.add(containerId, fragment, "tag");
+        fragmentTransaction.commit();
+    }
+
+    private class EventTestModule extends AbstractModule {
+        @Override protected void configure() {
+            bind(EventManager.class).toInstance(eventManager);
+        }
+    }
+}

--- a/roboguice/src/test/java/roboguice/fragment/provided/FragmentEventInjectionTest.java
+++ b/roboguice/src/test/java/roboguice/fragment/provided/FragmentEventInjectionTest.java
@@ -1,0 +1,123 @@
+package roboguice.fragment.provided;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import com.google.inject.AbstractModule;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.util.ActivityController;
+import roboguice.RoboGuice;
+import roboguice.activity.RoboActivity;
+import roboguice.event.EventManager;
+
+import static android.os.Build.VERSION_CODES.HONEYCOMB;
+
+//TODO : this could be made easier when switching to Robolectric 2.3
+@RunWith(RobolectricTestRunner.class)
+public class FragmentEventInjectionTest {
+
+    private EventManager eventManager = EasyMock.createMock(EventManager.class);
+
+    @Before
+    public void setup() {
+        RoboGuice.overrideApplicationInjector(Robolectric.application, new EventTestModule());
+    }
+
+    //http://blog.nikhaldimann.com/2013/10/10/robolectric-2-2-some-pages-from-the-missing-manual/
+    //http://stackoverflow.com/questions/11333354/how-can-i-test-fragments-with-robolectric
+    @TargetApi(HONEYCOMB)
+    @Test
+    public void testShouldReceiveEvents() {
+        //GIVEN
+        eventManager.registerObserver((Class) EasyMock.anyObject(), (roboguice.event.EventListener<?>) EasyMock.anyObject());
+        //try to keep FQN to see what belongs to activity and fragment
+        eventManager.fire(EasyMock.isA(roboguice.context.event.OnCreateEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.activity.event.OnContentChangedEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnAttachEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnCreateEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnActivityCreatedEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnViewCreatedEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.context.event.OnStartEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnStartEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.activity.event.OnResumeEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnResumeEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.activity.event.OnPauseEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnPauseEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.activity.event.OnStopEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnStopEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.context.event.OnDestroyEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnDestroyEvent.class));
+        eventManager.fire(EasyMock.isA(roboguice.fragment.event.OnDetachEvent.class));
+        eventManager.destroy();
+
+        EasyMock.replay(eventManager);
+
+        //WHEN
+        final ActivityController<ActivityEvent> activityController = Robolectric.buildActivity(ActivityEvent.class);
+
+        final ActivityEvent activity = activityController.get();
+        activityController.create();
+        activityController.postCreate(null);
+        activityController.start();
+        activityController.resume();
+        activityController.postResume();
+        activityController.visible();
+        startFragment(activity, activity.fragmentRef, ActivityEvent.CONTAINER_ID);
+        activityController.pause();
+        activityController.stop();
+        activityController.destroy();
+
+        //THEN
+        EasyMock.verify(eventManager);
+    }
+
+    public static class ActivityEvent extends RoboActivity {
+        public static final int CONTAINER_ID = 1;
+        FragmentEvent fragmentRef;
+
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            LinearLayout view = new LinearLayout(this);
+            view.setId(CONTAINER_ID);
+
+            setContentView(view);
+
+            fragmentRef = new FragmentEvent();
+        }
+
+        public static class FragmentEvent extends RoboFragment {
+
+            @Override
+            public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+                return new View(inflater.getContext());
+            }
+        }
+    }
+
+    // http://stackoverflow.com/questions/11333354/how-can-i-test-fragments-with-robolectric
+    protected static void startFragment(Activity activity, Fragment fragment, int containerId) {
+        final FragmentManager fragmentManager = activity.getFragmentManager();
+        final FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+        fragmentTransaction.add(containerId, fragment, "tag");
+        fragmentTransaction.commit();
+    }
+
+    private class EventTestModule extends AbstractModule {
+        @Override protected void configure() {
+            bind(EventManager.class).toInstance(eventManager);
+        }
+    }
+}

--- a/roboguice/src/test/java/roboguice/fragment/provided/FragmentInjectionTest.java
+++ b/roboguice/src/test/java/roboguice/fragment/provided/FragmentInjectionTest.java
@@ -1,9 +1,18 @@
 package roboguice.fragment.provided;
 
+import static android.os.Build.VERSION_CODES.HONEYCOMB;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
+import android.annotation.TargetApi;
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
+import android.widget.LinearLayout;
+import com.google.inject.AbstractModule;
+import org.easymock.EasyMock;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -11,7 +20,9 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.ActivityController;
 
+import roboguice.RoboGuice;
 import roboguice.activity.RoboActivity;
+import roboguice.event.EventManager;
 import roboguice.inject.InjectView;
 
 import com.google.inject.Inject;
@@ -32,7 +43,7 @@ public class FragmentInjectionTest {
     public void shadowActivityGetApplicationContextShouldNotReturnNull() {
         assertNotNull(new Activity().getApplicationContext());
     }
-	
+
     @Test
     public void shouldInjectPojosAndViewsIntoFragments() {
         final ActivityA activity = Robolectric.buildActivity(ActivityA.class).create().start().resume().get();
@@ -86,8 +97,6 @@ public class FragmentInjectionTest {
         assertThat(activity2.fragmentRef.v, equalTo(activity2.fragmentRef.ref));
     }
 
-
-
     public static class ActivityA extends RoboActivity {
         FragmentA fragmentRef;
 
@@ -98,7 +107,6 @@ public class FragmentInjectionTest {
             fragmentRef = new FragmentA();
             fragmentRef.onAttach(this);
             fragmentRef.onCreate(null);
-
         }
 
         public static class FragmentA extends RoboFragment {
@@ -111,11 +119,13 @@ public class FragmentInjectionTest {
             public void onCreate(Bundle savedInstanceState) {
                 super.onCreate(savedInstanceState);
             }
-            
+
             @Override
             public void onViewCreated(View view, Bundle savedInstanceState) {
                 super.onViewCreated(view, savedInstanceState);
             }
+
+            @TargetApi(HONEYCOMB)
             @Override
             public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
                 ref = new View(getActivity());
@@ -123,7 +133,6 @@ public class FragmentInjectionTest {
                 return ref;
             }
         }
-
     }
 
 
@@ -144,7 +153,6 @@ public class FragmentInjectionTest {
             fragmentRef = new FragmentB();
             fragmentRef.onAttach(this);
             fragmentRef.onCreate(null);
-
         }
 
         public static class FragmentB extends RoboFragment {
@@ -152,6 +160,7 @@ public class FragmentInjectionTest {
 
             View viewRef;
 
+            @TargetApi(HONEYCOMB)
             @Override
             public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
                 viewRef = new View(getActivity());
@@ -159,7 +168,6 @@ public class FragmentInjectionTest {
                 return viewRef;
             }
         }
-
     }
 
     public static class ActivityC extends RoboActivity {
@@ -177,7 +185,6 @@ public class FragmentInjectionTest {
             fragmentRef = new FragmentC();
             fragmentRef.onAttach(this);
             fragmentRef.onCreate(null);
-
         }
 
         public static class FragmentC extends RoboFragment {
@@ -185,6 +192,7 @@ public class FragmentInjectionTest {
 
             View viewRef;
 
+            @TargetApi(HONEYCOMB)
             @Override
             public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
                 viewRef = new View(getActivity());
@@ -192,7 +200,6 @@ public class FragmentInjectionTest {
                 return viewRef;
             }
         }
-
     }
 
 
@@ -209,17 +216,6 @@ public class FragmentInjectionTest {
             fragmentRef.onCreate(null);
 
             setContentView(new FrameLayout(this));
-            
-        }
-
-        @Override
-        protected void onPause() {
-            super.onPause();
-        }
-
-        @Override
-        protected void onResume() {
-            super.onResume();
         }
 
         public static class FragmentD extends RoboFragment {
@@ -227,6 +223,7 @@ public class FragmentInjectionTest {
 
             View ref;
 
+            @TargetApi(HONEYCOMB)
             @Override
             public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
                 ref = new View(getActivity());
@@ -239,7 +236,5 @@ public class FragmentInjectionTest {
                 super.onCreate(savedInstanceState);
             }
         }
-
     }
-
 }


### PR DESCRIPTION
This PR adds support for fragment events.

It works for both native/provided and support fragment.
Tests added.

Based on the old PR mentioned in the ticket.
