### PR TITLE
Overloading equalsIgnoreCase method with an extra Locale argument

### DIFF
--- a/roboguice/src/main/java/roboguice/util/Strings.java
+++ b/roboguice/src/main/java/roboguice/util/Strings.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 
 public final class Strings {
@@ -161,6 +162,10 @@ public final class Strings {
 
     public static boolean equalsIgnoreCase(Object a, Object b) {
         return Strings.toString(a).toLowerCase().equals(Strings.toString(b).toLowerCase());
+    }
+
+    public static boolean equalsIgnoreCase(Object a, Object b, Locale locale) {
+        return Strings.toString(a).toLowerCase(locale).equals(Strings.toString(b).toLowerCase(locale));
     }
 
     public static String[] chunk(String str, int chunkSize) {


### PR DESCRIPTION
Changes:
- Added overload for `equalsIgnoreCase` method with an extra Locale argument, that can be used to avoid false negatives in apps that support multiple languages.
  For example in some languages the lowercase characters are different from the ones in English, so if you are using `equalsIgnoreCase` for some API related string transformations (assuming your API uses English as a default language), and you don't specify `Locale.ENGLISH` when you do so, the equals check may return false even if the strings are exactly the same before applying `toLowerCase`.
